### PR TITLE
Update net.cc - fixes a compiler error on latest MacOS

### DIFF
--- a/src/net.cc
+++ b/src/net.cc
@@ -112,7 +112,7 @@ int unix_listen(const string &path)
 	strcpy(sun.sun_path, path.c_str());
 
 	mode_t um = umask(077);
-	if (bind(sfd, reinterpret_cast<sockaddr *>(&sun), sizeof(sun)) < 0) {
+	if (::bind(sfd, reinterpret_cast<sockaddr *>(&sun), sizeof(sun)) < 0) {
 		umask(um);
 		close(sfd);
 		return -1;


### PR DESCRIPTION
tl;dr the issue described [here](https://stackoverflow.com/questions/65102143/socket-bind-error-invalid-operands-to-binary-expression) arises when building on latest MacOS.

I notice all the other calls to bind are properly prefixed with the :: except this one, so I figure this won't have any side effects.

I can test on Linux and some other stuff later (BSD, Solaris 9).